### PR TITLE
Remove IDE settings from Git and ignore in future

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.metadata/

--- a/.metadata/.plugins/org.eclipse.core.runtime/.settings/org.springframework.ide.eclipse.boot.dash:Docker.prefs
+++ b/.metadata/.plugins/org.eclipse.core.runtime/.settings/org.springframework.ide.eclipse.boot.dash:Docker.prefs
@@ -1,2 +1,0 @@
-eclipse.preferences.version=1
-runTargets-v2=


### PR DESCRIPTION
Removed IDE-specific configuration files (e.g., .idea/, *.iml, .vscode/) from the repository to reduce noise, prevent potential merge conflicts, and keep the project clean for all contributors regardless of their development environment.

Also updated the .gitignore file to ensure these files are not tracked in the future.

This change promotes consistency and avoids committing machine- or developer-specific settings.
