### PR TITLE
 Implement EventLifecycle scheduler to auto-update past events 

### DIFF
--- a/Event-Hive_Backend/src/main/java/com/eventhive/Application.java
+++ b/Event-Hive_Backend/src/main/java/com/eventhive/Application.java
@@ -6,8 +6,10 @@ import org.modelmapper.convention.MatchingStrategies;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication // includes @Configuration
+@EnableScheduling
 public class Application {
 
 	public static void main(String[] args) {

--- a/Event-Hive_Backend/src/main/java/com/eventhive/scheduler/EventLifecycleService.java
+++ b/Event-Hive_Backend/src/main/java/com/eventhive/scheduler/EventLifecycleService.java
@@ -1,0 +1,34 @@
+package com.eventhive.scheduler;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import com.eventhive.entities.Event;
+import com.eventhive.entities.enums.EventLifeCycleStatus;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class EventLifecycleService {
+
+    private final ScheduleEventDao eventDao;
+    @Scheduled(cron = "0 * * * * *")
+    //	@Scheduled(cron = "0 0 * * * *") // Runs every hour
+    public void updateCompletedEvents() {
+        List<Event> pastEvents = eventDao.findByEventDateBeforeAndLifecycleStatus(
+            LocalDateTime.now(), EventLifeCycleStatus.UPCOMING);
+
+        for (Event event : pastEvents) {
+            event.setLifecycleStatus(EventLifeCycleStatus.COMPLETED);
+            event.setUpdatedAt(LocalDateTime.now());
+        }
+
+        if (!pastEvents.isEmpty()) {
+            eventDao.saveAll(pastEvents);
+        }
+    }
+}

--- a/Event-Hive_Backend/src/main/java/com/eventhive/scheduler/ScheduleEventDao.java
+++ b/Event-Hive_Backend/src/main/java/com/eventhive/scheduler/ScheduleEventDao.java
@@ -1,0 +1,16 @@
+package com.eventhive.scheduler;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.eventhive.entities.Artist;
+import com.eventhive.entities.Event;
+import com.eventhive.entities.enums.EventLifeCycleStatus;
+
+public interface ScheduleEventDao extends JpaRepository<Event, Long>{
+
+	List<Event> findByEventDateBeforeAndLifecycleStatus(LocalDateTime now, EventLifeCycleStatus status);
+	
+}


### PR DESCRIPTION
Introduced a scheduled task to automatically update the lifecycle status of past events.

- Created EventLifecycleService with a scheduled method that runs every min
- The method identifies events with a past event_date and UPCOMING status.
- Updates those events to COMPLETED and sets the updated_at timestamp.
- Added @EnableScheduling in the Application class to activate scheduling.
- Ensured changes are persisted using @Transactional and repository.saveAll().